### PR TITLE
WAZO-2798 Upgrade to Asterisk 19.5.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: wazo-res-consul
 Section: comm
 Priority: extra
 Maintainer: Wazo Maintainers <dev@wazo.community>
-Build-Depends: debhelper (>= 9), asterisk-dev (>= 8:18), libconsul-c
+Build-Depends: debhelper (>= 9), asterisk-dev (>= 8:19), libconsul-c
 Standards-Version: 3.9.6
 
 Package: wazo-res-consul
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, asterisk (>= 8:18), libconsul-c
+Depends: ${shlibs:Depends}, ${misc:Depends}, asterisk (>= 8:19), libconsul-c
 Description: Consul module for the Asterisk IPBX
  Connects to a Consul server for service discovering.
  .
@@ -15,7 +15,7 @@ Description: Consul module for the Asterisk IPBX
 Package: wazo-res-consul-dev
 Architecture: all
 Section: devel
-Depends: ${misc:Depends}, asterisk-dev (>= 8:18), libconsul-c
+Depends: ${misc:Depends}, asterisk-dev (>= 8:19), libconsul-c
 Description: Consul module for the Asterisk IPBX
  Connects to a Consul server for service discovering.
  .


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/asterisk/pull/102