### PR TITLE
Add token support

### DIFF
--- a/res_consul.c
+++ b/res_consul.c
@@ -213,6 +213,10 @@ static int load_res(int start)
         return 1;
     }
 
+    if (!ast_strlen_zero(global_config.token)) {
+        consul_client_setup_token(active_client, global_config.token);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Added Consul Token support by call `consul_client_setup_token()` from https://github.com/wazo-platform/libconsul-c/pull/4.
The feature was lost while migration from res_discovery_consul to res_consul_discovery.