### PR TITLE
Add tls_server_name and tls_skip_verify params to ast_consul_service_check

### DIFF
--- a/asterisk/consul.h
+++ b/asterisk/consul.h
@@ -39,6 +39,8 @@ struct ast_consul_client;
 struct ast_consul_service_check {
    const char *http;
    int interval;
+   const char *tls_server_name;
+   int tls_skip_verify;
 };
 
 typedef int (*ast_consul_watch_keys_callback) (int key_count, char **keys);

--- a/res_consul.c
+++ b/res_consul.c
@@ -245,6 +245,8 @@ int ast_consul_service_register(const char* id,
             service.checks[i] = (struct consul_check_t*) ast_calloc(1, sizeof(consul_check_t));
             service.checks[i]->http = checks[i]->http;
             service.checks[i]->interval = checks[i]->interval;
+            service.checks[i]->tls_server_name = checks[i]->tls_server_name;
+            service.checks[i]->tls_skip_verify = checks[i]->tls_skip_verify;
         }
     }
 


### PR DESCRIPTION
Added `tls_server_name` and `tls_skip_verify` params to `ast_consul_service_check`

[Check - Agent HTTP API](https://www.consul.io/api-docs/v1.12.x/agent/check)

See also: [Add TLSServerName and TLSSkipVerify to the check](https://github.com/wazo-platform/libconsul-c/pull/5)